### PR TITLE
Update extras.md - Fixed path for src/main.py

### DIFF
--- a/docs/services/extras.md
+++ b/docs/services/extras.md
@@ -87,7 +87,7 @@ To trigger a symlink repair, you can use one of the following methods:
 === "Local"
 
     ```bash
-    poetry run python /src/main.py --fix_symlinks
+    poetry run python ./src/main.py --fix_symlinks
     ```
 
 === "Env Variable"


### PR DESCRIPTION
Updated extras.md to use relative path `./src/main.py` instead of absolute path `src/main.py` which would cause `[Errno 2] No such file or directory` when executing through `docker exec -it riven sh` bash shell

Noticed this while attempting to fix my improperly configured `zurb` and `riven` mount symlinks.